### PR TITLE
feat: implement multi-stage Docker build and configure network subnets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:24-alpine AS build
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install ALL dependencies (including dev dependencies for building)
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the TypeScript application
+RUN npm run build
+
+# Production stage
+FROM node:24-alpine AS production
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install only production dependencies
+RUN npm ci --omit=dev
+
+# Copy compiled code from build stage
+COPY --from=build /app/dist ./dist
+
+# Expose port (if your app uses one)
+EXPOSE 3000
+
+# Start the application
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,24 +2,23 @@ version: '3.8'
 
 services:
   twitch-bot:
-    image: node:24-alpine
+    build: .
     container_name: twitch-bot
     working_dir: /app
-    volumes:
-      - .:/app
-      - /app/node_modules
     environment:
       - NODE_ENV=production
       - BOT_USERNAME=${BOT_USERNAME}
       - OAUTH_TOKEN=${OAUTH_TOKEN}
       - CHANNELS=${CHANNELS}
-    command: sh -c "npm ci --omit=dev && npm run build && npm start"
     restart: unless-stopped
     networks:
-      - bot-network
+      public_net:
+        ipv4_address: 172.18.1.3
+      nats_net:
+        ipv4_address: 172.18.2.3
     healthcheck:
-      test: ["CMD", "node", "-e", "console.log('Health check passed')"]
-      interval: 30s
+      test: ['CMD', 'node', '-e', "console.log('Health check passed')"]
+      interval: 15s
       timeout: 10s
       retries: 3
       start_period: 40s
@@ -63,9 +62,19 @@ services:
   #   restart: unless-stopped
 
 networks:
-  bot-network:
+  public_net:
+    name: public_net
     driver: bridge
-
+    ipam:
+      config:
+        - subnet: 172.18.1.0/24
+          gateway: 172.18.1.1
+  nats_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.18.2.0/24
+          gateway: 172.18.2.1
 # Uncomment if using database/redis services
 # volumes:
 #   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
     working_dir: /app
     environment:
       - NODE_ENV=production
-      - BOT_USERNAME=${BOT_USERNAME}
-      - OAUTH_TOKEN=${OAUTH_TOKEN}
-      - CHANNELS=${CHANNELS}
+      - USERNAME=${USERNAME}
+      - ACCESS_CODE=${ACCESS_CODE}
     restart: unless-stopped
     networks:
       public_net:


### PR DESCRIPTION
This pull request introduces a multi-stage Docker build and updates the `docker-compose.yml` file to improve containerization and networking for the Twitch bot application. Key changes include the addition of a production-ready `Dockerfile`, updates to the `docker-compose.yml` file to use the build context instead of a pre-built image, and the introduction of custom bridge networks for better IP management.

### Dockerfile changes:
* Added a multi-stage Docker build in `Dockerfile` to separate the build and production stages. This ensures that only production dependencies and compiled code are included in the final image.

### `docker-compose.yml` changes:
* Updated the `twitch-bot` service to use the build context (`build: .`) instead of pulling a pre-built image (`image: node:24-alpine`). Removed unnecessary volumes and commands since the application is now built in the `Dockerfile`.
* Added two custom bridge networks, `public_net` and `nats_net`, with specific subnets and gateways for better control over IP addressing. Updated the `twitch-bot` service to use these networks.
* Adjusted the health check interval for the `twitch-bot` service from 30 seconds to 15 seconds to improve responsiveness in monitoring.