### PR TITLE
Hotfix/network name change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - USERNAME=${USERNAME}
       - ACCESS_CODE=${ACCESS_CODE}
     restart: unless-stopped
+    volumes:
+      - logs_data:/app/logs
     networks:
       public_net:
         ipv4_address: 172.18.1.3
@@ -21,6 +23,18 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+  log-viewer:
+    image: nginx:alpine
+    container_name: twitch-bot-logs
+    ports:
+      - '8080:80'
+    volumes:
+      - logs_data:/usr/share/nginx/html/logs:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - public_net
+    depends_on:
+      - twitch-bot
 
   # Optional: Add a database service if needed
   # postgres:
@@ -74,8 +88,10 @@ networks:
       config:
         - subnet: 172.18.2.0/24
           gateway: 172.18.2.1
+
+volumes:
+  logs_data:
 # Uncomment if using database/redis services
-# volumes:
 #   postgres_data:
 #   redis_data:
 #   prometheus_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,11 +28,13 @@ services:
     container_name: twitch-bot-logs
     ports:
       - '8082:8080'
+    restart: unless-stopped
     volumes:
       - logs_data:/usr/share/nginx/html/logs:ro
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     networks:
-      - public_net
+      public_net: 
+        ipv4_address: 172.18.1.4
     depends_on:
       - twitch-bot
 
@@ -83,6 +85,7 @@ networks:
         - subnet: 172.18.1.0/24
           gateway: 172.18.1.1
   nats_net:
+    name: nats_net
     driver: bridge
     ipam:
       config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     image: nginx:alpine
     container_name: twitch-bot-logs
     ports:
-      - '8080:80'
+      - '8082:8080'
     volumes:
       - logs_data:/usr/share/nginx/html/logs:ro
       - ./nginx.conf:/etc/nginx/nginx.conf:ro

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    server {
+        listen 80;
+        server_name localhost;
+        
+        # Enable directory listing
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_localtime on;
+        
+        # Root directory for logs
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri $uri/ =404;
+        }
+        
+        # Serve log files with proper content type
+        location ~ \.log$ {
+            root /usr/share/nginx/html;
+            add_header Content-Type text/plain;
+        }
+        
+        # Custom styling for directory listing
+        location = /logs/ {
+            root /usr/share/nginx/html;
+            autoindex on;
+            autoindex_exact_size off;
+            autoindex_localtime on;
+        }
+    }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -30,7 +30,7 @@ const settings = {
     //   (i.e., error, fatal, but not other levels)
     //
     new winston.transports.File({
-      filename: 'error.log',
+      filename: 'logs/error.log',
       level: 'error',
     }),
     //
@@ -38,7 +38,7 @@ const settings = {
     //   (i.e., fatal, error, warn, and info, but not trace)
     //
     new winston.transports.File({
-      filename: 'combined.log',
+      filename: 'logs/combined.log',
       level: 'info',
     }),
   ],


### PR DESCRIPTION
This pull request introduces a log viewing feature by integrating an Nginx-based log viewer service and adjusting how logs are stored and accessed. The changes focus on adding a new service for browsing logs, updating logger paths to enable sharing logs between containers, and configuring Docker Compose to support these improvements.

**Log viewing and sharing enhancements:**

* Added a new `log-viewer` service using the `nginx:alpine` image in `docker-compose.yml`, which exposes log files via port 8082 and depends on the `twitch-bot` service. It mounts the shared `logs_data` volume and includes a custom Nginx configuration for directory listing and log serving. (`docker-compose.yml`, [docker-compose.ymlR26-R39](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R26-R39))
* Introduced a shared `logs_data` volume in `docker-compose.yml` and mounted it to both the `twitch-bot` service (for log writing) and the `log-viewer` service (for log reading). (`docker-compose.yml`, [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R13-R14) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R88-L78)

**Logger configuration updates:**

* Changed log file output paths in `src/utils/logger.ts` so that error and combined logs are written to the `logs/` directory, ensuring they are accessible to the log viewer. (`src/utils/logger.ts`, [src/utils/logger.tsL33-R41](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L33-R41))

**Nginx configuration for log viewing:**

* Added a new `nginx.conf` file to configure Nginx for directory listing, log file serving, and custom styling for log browsing. (`nginx.conf`, [nginx.confR1-R38](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR1-R38))