### PR TITLE
NATS_SOCKET env variable added

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+.env
+.nyc_output
+coverage
+.DS_Store
+dist
+*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   twitch-bot:
     build: .
@@ -9,6 +7,7 @@ services:
       - NODE_ENV=production
       - USERNAME=${USERNAME}
       - ACCESS_CODE=${ACCESS_CODE}
+      - NATS_SOCKET=${NATS_SOCKET}
     restart: unless-stopped
     volumes:
       - logs_data:/app/logs
@@ -33,7 +32,7 @@ services:
       - logs_data:/usr/share/nginx/html/logs:ro
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     networks:
-      public_net: 
+      public_net:
         ipv4_address: 172.18.1.4
     depends_on:
       - twitch-bot

--- a/index.ts
+++ b/index.ts
@@ -19,10 +19,11 @@ async function bootstrap() {
     });
 
     await bot.connect();
-    logger.info('bot successfully made');
+    logger.info('Bot successfully made');
 
-    const nc = await connect();
-    logger.info('Connected to NATS');
+    const natsSocket = process.env.NATS_SOCKET || 'nats://localhost:4222';
+    const natsServers = [{ servers: [natsSocket] }];
+    const nc = await connect(natsServers[0]);
 
     const sc = StringCodec();
     const subject = 'twitch.messages';


### PR DESCRIPTION
This pull request introduces improvements to the Docker setup and enhances the NATS connection configuration for the Twitch bot. The most significant changes are the addition of a `.dockerignore` file to optimize Docker builds, updating environment variable handling for NATS connectivity, and refining the NATS connection logic in `index.ts`.

**Docker and environment configuration:**

* Added a `.dockerignore` file to exclude unnecessary files and directories from Docker builds, improving build performance and reducing image size.
* Updated the `docker-compose.yml` service environment to include the `NATS_SOCKET` variable, allowing configuration of the NATS server address via environment variables.
* Removed the version declaration from `docker-compose.yml` for compatibility with newer Compose specifications.

**NATS connection logic:**

* Modified `index.ts` to read the NATS server address from the `NATS_SOCKET` environment variable, defaulting to `nats://localhost:4222` if not set, and updated the NATS connection code accordingly.

These changes streamline deployment, improve flexibility for different environments, and enhance maintainability.